### PR TITLE
WIP add clear which issues multiple calls to the cancel each of the multi-sigs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -689,11 +689,13 @@ decl_module! {
 			}
 
 			<Multisigs<T>>::remove_prefix(&multi_account_id);
-			ensure!(succeeded == max_cancellations, Error::<T>::MultisigCancelIncomplete);
 
 			for m_sig in cancelled_multisigs{
 				Self::deposit_event(RawEvent::MultisigCancelled(m_sig.depositor, timepoint, multi_account_id.clone()));
 			}
+
+			ensure!(succeeded == max_cancellations, Error::<T>::MultisigCancelIncomplete);
+
 			Ok(())
 		}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -682,10 +682,12 @@ decl_module! {
 			let active_multisigs = <Multisigs<T>>::iter_prefix(&multi_account_id);
 			for m_sig in active_multisigs.take(max_cancellations as usize){
 				ensure!(who == multi_account_id || who == m_sig.depositor, Error::<T>::NotOwner);
-
-				let _ = T::Currency::unreserve(&m_sig.depositor, m_sig.deposit);
 				cancelled_multisigs.push(m_sig);
 				succeeded += 1;
+			}
+
+			for m_sig in cancelled_multisigs.iter(){
+				let _ = T::Currency::unreserve(&m_sig.depositor, m_sig.deposit);
 			}
 
 			<Multisigs<T>>::remove_prefix(&multi_account_id);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1059,6 +1059,42 @@ mod tests {
     }
 
     #[test]
+    fn clear_multisig_with_zero_max_cancellation() {
+        new_test_ext().execute_with(|| {
+            let multi_id = MultiAccount::multi_account_id(2);
+            let call = Box::new(Call::Balances(BalancesCall::transfer(6, 15)));
+            let hash = call.using_encoded(blake2_256);
+            assert_ok!(MultiAccount::create(Origin::signed(1), 3, vec![2, 3]));
+            assert_ok!(MultiAccount::approve(
+                Origin::signed(1),
+                multi_id,
+                None,
+                hash.clone()
+            ));
+            assert_ok!(MultiAccount::approve(
+                Origin::signed(2),
+                multi_id,
+                Some(now()),
+                hash.clone()
+            ));
+            assert_eq!(Balances::free_balance(1), 12);
+            assert_eq!(Balances::reserved_balance(1), 8);
+            assert_ok!(MultiAccount::clear(
+                Origin::signed(1),
+                multi_id,
+				0,
+                now(),
+            ),);
+			// nothing is cancelled, balance stays the same
+            assert_eq!(Balances::free_balance(1), 12);
+			// reserve balance stays the same
+            assert_eq!(Balances::reserved_balance(1), 8);
+			// there should be no MultiSigCancelled event, shows the last event executed: Approval
+            expect_event(RawEvent::MultisigApproval(2, now(), multi_id));
+        });
+    }
+
+    #[test]
     fn timepoint_checking_works() {
         new_test_ext().execute_with(|| {
             let multi_id = MultiAccount::multi_account_id(2);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -681,7 +681,6 @@ decl_module! {
 			let mut cancelled_multisigs = Vec::with_capacity(max_cancellations as usize);
 			let active_multisigs = <Multisigs<T>>::iter_prefix(&who);
 			for m_sig in active_multisigs.take(max_cancellations as usize){
-				ensure!(m_sig.when == timepoint, Error::<T>::WrongTimepoint);
 				ensure!(who == multi_account_id || who == m_sig.depositor, Error::<T>::NotOwner);
 
 				let _ = T::Currency::unreserve(&m_sig.depositor, m_sig.deposit);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1026,7 +1026,7 @@ mod tests {
     }
 
     #[test]
-    fn cleaar_multisig_works() {
+    fn clear_multisig_works() {
         new_test_ext().execute_with(|| {
             let multi_id = MultiAccount::multi_account_id(2);
             let call = Box::new(Call::Balances(BalancesCall::transfer(6, 15)));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -679,7 +679,7 @@ decl_module! {
 			let mut succeeded = 0;
 			let who = ensure_signed(origin)?;
 			let mut cancelled_multisigs = Vec::with_capacity(max_cancellations as usize);
-			let active_multisigs = <Multisigs<T>>::iter_prefix(&who);
+			let active_multisigs = <Multisigs<T>>::iter_prefix(&multi_account_id);
 			for m_sig in active_multisigs.take(max_cancellations as usize){
 				ensure!(who == multi_account_id || who == m_sig.depositor, Error::<T>::NotOwner);
 


### PR DESCRIPTION
and an alternative clear2 function which deposit the event only after each of the operations succeeds